### PR TITLE
v1.03

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,5 @@
 1.03	2017-05-02
-		- 
+		- Fix for 'Bug #121293 for Term-ReadLine-Tiny: Experimental pop on scalar is now forbidden'
 
 1.02	2017-05-02
 		- POD changes

--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+1.03	2017-05-02
+		- 
+
 1.02	2017-05-02
 		- POD changes
 		- Little fixes

--- a/README
+++ b/README
@@ -2,7 +2,7 @@ NAME
     Term::ReadLine::Tiny - Tiny implementation of ReadLine
 
 VERSION
-    version 1.02
+    version 1.03
 
 SYNOPSIS
             use Term::ReadLine::Tiny;

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Term::ReadLine::Tiny - Tiny implementation of ReadLine
 
 # VERSION
 
-version 1.02
+version 1.03
 
 # SYNOPSIS
 

--- a/lib/Term/ReadLine/Tiny.pm
+++ b/lib/Term/ReadLine/Tiny.pm
@@ -5,7 +5,7 @@ Term::ReadLine::Tiny - Tiny implementation of ReadLine
 
 =head1 VERSION
 
-version 1.02
+version 1.03
 
 =head1 SYNOPSIS
 
@@ -65,7 +65,7 @@ require Term::ReadKey;
 BEGIN
 {
 	require Exporter;
-	our $VERSION     = '1.02';
+	our $VERSION     = '1.03';
 	our @ISA         = qw(Exporter);
 	our @EXPORT      = qw();
 	our @EXPORT_OK   = qw();

--- a/lib/Term/ReadLine/Tiny.pm
+++ b/lib/Term/ReadLine/Tiny.pm
@@ -301,7 +301,7 @@ sub readline
 				{
 					print $out $char;
 					$history->[$#$history] = $line;
-					pop $history unless defined($minline) and length($line) >= $minline;
+					pop @$history unless defined($minline) and length($line) >= $minline;
 					$result = $line;
 					last;
 				}

--- a/lib/Term/ReadLine/Tiny/readline.pm
+++ b/lib/Term/ReadLine/Tiny/readline.pm
@@ -5,7 +5,7 @@ Term::ReadLine::Tiny::readline - A non-OO package of Term::ReadLine::Tiny
 
 =head1 VERSION
 
-version 1.02
+version 1.03
 
 =head1 SYNOPSIS
 
@@ -34,7 +34,7 @@ use Term::ReadLine::Tiny;
 BEGIN
 {
 	require Exporter;
-	our $VERSION     = '1.02';
+	our $VERSION     = '1.03';
 	our @ISA         = qw(Exporter);
 	our @EXPORT      = qw(readline readkey);
 	our @EXPORT_OK   = qw();


### PR DESCRIPTION
- Fix for 'Bug #121293 for Term-ReadLine-Tiny: Experimental pop on scalar is now forbidden'