### PR TITLE
^A & ^E keys (Unix-y Home & End)

### DIFF
--- a/lib/Term/ReadLine/Tiny.pm
+++ b/lib/Term/ReadLine/Tiny.pm
@@ -46,9 +46,9 @@ B<C<RightArrow>:> Moves cursor forward to one character.
 
 B<C<LeftArrow>:> Moves cursor back to one character.
 
-B<C<Home>:> Moves cursor to the start of the line.
+B<C<Home> or C<^A>:> Moves cursor to the start of the line.
 
-B<C<End>:> Moves cursor to the end of the line.
+B<C<End> or C<^E>:> Moves cursor to the end of the line.
 
 B<C<^D>:> Aborts the operation. Returns C<undef>.
 
@@ -309,6 +309,14 @@ sub readline
 				{
 					$backspace->();
 				}
+                when (/\x01/)    # ^A
+                {
+					$home->();
+                }
+                when (/\x05/)    # ^E
+                {
+					$end->();
+                }
 				when (/[\x00-\x1F]|\x7F/)
 				{
 					$print->($char);


### PR DESCRIPTION

First, thanks for this module. I was looking for a light replacement of Term::ReadLine::Gnu or Term::ReadLine::Perl5 and that is exactly the code you wrote.

When testing the module, I missed the ^A and ^E I was used to. This PR proposes to support them. I think they complement some of the keys already supported, like ^H, ^J, etc. https://en.wikipedia.org/wiki/Control_key