### PR TITLE
v1.08

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 1.08	2017-05-11
 		- Added keys that starting with ^[O
-		- Returns always UTF-8 encoded string (binary string) when input is UTF-8
+		- Returns binary encoded UTF-8 string when input handle has :utf8 layer and utf8 feature is true
 
 1.07	2017-05-09
 		- Bug fix: Cursor appearance at end of terminal line

--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+1.08	2017-05-11
+		- 
+
 1.07	2017-05-09
 		- Bug fix: Cursor appearance at end of terminal line
 		- Line auto completion by Tab

--- a/Changes
+++ b/Changes
@@ -1,5 +1,5 @@
 1.08	2017-05-11
-		- 
+		- Added keys that starting with ^[O
 
 1.07	2017-05-09
 		- Bug fix: Cursor appearance at end of terminal line

--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 1.08	2017-05-11
 		- Added keys that starting with ^[O
+		- Returns always UTF-8 encoded string (binary string) when input is UTF-8
 
 1.07	2017-05-09
 		- Bug fix: Cursor appearance at end of terminal line

--- a/README
+++ b/README
@@ -169,15 +169,16 @@ Other Methods and Functions
     argument "c".
 
 UTF-8
-    "Term::ReadLine::Tiny" fully supports UTF-8. If no input/output handle
-    specified when calling "new()" or "newTTY()", opens console input/output
-    file handles with ":utf8" layer by "LANG" environment variable. You
-    should set ":utf8" layer explicitly, if input/output file handles
-    specified with "new()" or "newTTY()".
+    "Term::ReadLine::Tiny" fully supports UTF-8. If no input/output file
+    handle specified when calling "new()" or "newTTY()", opens console
+    input/output file handles with ":utf8" layer by "LANG" environment
+    variable. You should set ":utf8" layer explicitly, if input/output file
+    handles specified with "new()" or "newTTY()".
 
             $term = Term::ReadLine::Tiny->new("", $in, $out);
             binmode($term->IN, ":utf8");
             binmode($term->OUT, ":utf8");
+            $term->utf8(0); # to get UTF-8 marked string
             while ( defined($_ = $term->readline("Prompt: ")) )
             {
                     print "$_\n";

--- a/README
+++ b/README
@@ -160,7 +160,7 @@ Other Methods and Functions
 
   utf8([$enable])
     If $enable is "TRUE", all read methods return that binary encoded UTF-8
-    string.
+    string as possible.
 
     Returns the old value.
 
@@ -178,7 +178,7 @@ UTF-8
             $term = Term::ReadLine::Tiny->new("", $in, $out);
             binmode($term->IN, ":utf8");
             binmode($term->OUT, ":utf8");
-            $term->utf8(0); # to get UTF-8 marked string
+            $term->utf8(0); # to get UTF-8 marked string as possible
             while ( defined($_ = $term->readline("Prompt: ")) )
             {
                     print "$_\n";

--- a/README
+++ b/README
@@ -126,7 +126,7 @@ Standard Methods and Functions
     *   *changehistory* is present, default "TRUE". See "changehistory"
         method.
 
-    *   *utf8* is present. "TRUE" if input file handle has ":utf8" layer.
+    *   *utf8* is present, default "TRUE". See "utf8" method.
 
 Additional Methods and Functions
   newTTY([$IN[, $OUT]])
@@ -158,8 +158,14 @@ Other Methods and Functions
 
     Returns "undef" on "EOF".
 
+  utf8([$enable])
+    If $enable is "TRUE", all read methods return that binary encoded UTF-8
+    string.
+
+    Returns the old value.
+
   encode_controlchar($c)
-    encodes if argument "c" is a control character, otherwise returns
+    encodes if argument $c is a control character, otherwise returns
     argument "c".
 
 UTF-8

--- a/README
+++ b/README
@@ -2,7 +2,7 @@ NAME
     Term::ReadLine::Tiny - Tiny implementation of ReadLine
 
 VERSION
-    version 1.07
+    version 1.08
 
 SYNOPSIS
             use Term::ReadLine::Tiny;

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ This features are present:
 - _gethistory_ is present, always `TRUE`.
 - _sethistory_ is present, always `TRUE`.
 - _changehistory_ is present, default `TRUE`. See `changehistory` method.
-- _utf8_ is present. `TRUE` if input file handle has `:utf8` layer.
+- _utf8_ is present, default `TRUE`. See `utf8` method.
 
 # Additional Methods and Functions
 
@@ -160,9 +160,15 @@ reads a key from input and echoes if _echo_ argument is `TRUE`.
 
 Returns `undef` on `EOF`.
 
+## utf8(\[$enable\])
+
+If `$enable` is `TRUE`, all read methods return that binary encoded UTF-8 string.
+
+Returns the old value.
+
 ## encode\_controlchar($c)
 
-encodes if argument `c` is a control character, otherwise returns argument `c`.
+encodes if argument `$c` is a control character, otherwise returns argument `c`.
 
 # UTF-8
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Term::ReadLine::Tiny - Tiny implementation of ReadLine
 
 # VERSION
 
-version 1.07
+version 1.08
 
 # SYNOPSIS
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Returns `undef` on `EOF`.
 
 ## utf8(\[$enable\])
 
-If `$enable` is `TRUE`, all read methods return that binary encoded UTF-8 string.
+If `$enable` is `TRUE`, all read methods return that binary encoded UTF-8 string as possible.
 
 Returns the old value.
 
@@ -179,7 +179,7 @@ layer explicitly, if input/output file handles specified with `new()` or `newTTY
         $term = Term::ReadLine::Tiny->new("", $in, $out);
         binmode($term->IN, ":utf8");
         binmode($term->OUT, ":utf8");
-        $term->utf8(0); # to get UTF-8 marked string
+        $term->utf8(0); # to get UTF-8 marked string as possible
         while ( defined($_ = $term->readline("Prompt: ")) )
         {
                 print "$_\n";

--- a/README.md
+++ b/README.md
@@ -172,13 +172,14 @@ encodes if argument `$c` is a control character, otherwise returns argument `c`.
 
 # UTF-8
 
-`Term::ReadLine::Tiny` fully supports UTF-8. If no input/output handle specified when calling `new()` or `newTTY()`,
+`Term::ReadLine::Tiny` fully supports UTF-8. If no input/output file handle specified when calling `new()` or `newTTY()`,
 opens console input/output file handles with `:utf8` layer by `LANG` environment variable. You should set `:utf8`
 layer explicitly, if input/output file handles specified with `new()` or `newTTY()`.
 
         $term = Term::ReadLine::Tiny->new("", $in, $out);
         binmode($term->IN, ":utf8");
         binmode($term->OUT, ":utf8");
+        $term->utf8(0); # to get UTF-8 marked string
         while ( defined($_ = $term->readline("Prompt: ")) )
         {
                 print "$_\n";

--- a/lib/Term/ReadLine/Tiny.pm
+++ b/lib/Term/ReadLine/Tiny.pm
@@ -449,6 +449,7 @@ sub readline
 			$esc = undef;
 		}
 	}
+	utf8::encode($result) if defined($result) and utf8::is_utf8($result);
 
 	Term::ReadKey::ReadMode('restore', $self->{IN});
 	$self->{readmode} = '';
@@ -653,7 +654,15 @@ Returns copy of the history in Array.
 sub gethistory
 {
 	my $self = shift;
-	return @{$self->{history}};
+	my @result = @{$self->{history}};
+	if ($self->{features}->{utf8})
+	{
+		for (my $i = 0; $i < @result; $i++)
+		{
+			utf8::encode($result[$i]) if utf8::is_utf8($result[$i]);
+		}
+	}
+	return @result;
 }
 sub GetHistory
 {
@@ -761,6 +770,7 @@ sub readkey
 			last;
 		}
 	}
+	utf8::encode($result) if defined($result) and utf8::is_utf8($result);
 
 	Term::ReadKey::ReadMode('restore', $self->{IN});
 	$self->{readmode} = '';

--- a/lib/Term/ReadLine/Tiny.pm
+++ b/lib/Term/ReadLine/Tiny.pm
@@ -375,29 +375,29 @@ sub readline
 		{
 			given ($esc)
 			{
-				when (/^\[(A|0A)/)
+				when (/^(\[|O)(A|0A)/)
 				{
 					$up->();
 				}
-				when (/^\[(B|0B)/)
+				when (/^(\[|O)(B|0B)/)
 				{
 					$down->();
 				}
-				when (/^\[(C|0C)/)
+				when (/^(\[|O)(C|0C)/)
 				{
 					$right->();
 				}
-				when (/^\[(D|0D)/)
+				when (/^(\[|O)(D|0D)/)
 				{
 					$left->();
 				}
-				when (/^\[(H|0H)/)
-				{
-					$home->();
-				}
-				when (/^\[(F|0F)/)
+				when (/^(\[|O)(F|0F)/)
 				{
 					$end->();
+				}
+				when (/^(\[|O)(H|0H)/)
+				{
+					$home->();
 				}
 				when (/^\[(\d)~/)
 				{

--- a/lib/Term/ReadLine/Tiny.pm
+++ b/lib/Term/ReadLine/Tiny.pm
@@ -825,13 +825,14 @@ sub encode_controlchar
 __END__
 =head1 UTF-8
 
-C<Term::ReadLine::Tiny> fully supports UTF-8. If no input/output handle specified when calling C<new()> or C<newTTY()>,
+C<Term::ReadLine::Tiny> fully supports UTF-8. If no input/output file handle specified when calling C<new()> or C<newTTY()>,
 opens console input/output file handles with C<:utf8> layer by C<LANG> environment variable. You should set C<:utf8>
 layer explicitly, if input/output file handles specified with C<new()> or C<newTTY()>.
 
 	$term = Term::ReadLine::Tiny->new("", $in, $out);
 	binmode($term->IN, ":utf8");
 	binmode($term->OUT, ":utf8");
+	$term->utf8(0); # to get UTF-8 marked string
 	while ( defined($_ = $term->readline("Prompt: ")) )
 	{
 		print "$_\n";

--- a/lib/Term/ReadLine/Tiny.pm
+++ b/lib/Term/ReadLine/Tiny.pm
@@ -5,7 +5,7 @@ Term::ReadLine::Tiny - Tiny implementation of ReadLine
 
 =head1 VERSION
 
-version 1.07
+version 1.08
 
 =head1 SYNOPSIS
 
@@ -75,7 +75,7 @@ require Term::ReadKey;
 BEGIN
 {
 	require Exporter;
-	our $VERSION     = '1.07';
+	our $VERSION     = '1.08';
 	our @ISA         = qw(Exporter);
 	our @EXPORT      = qw();
 	our @EXPORT_OK   = qw();

--- a/lib/Term/ReadLine/Tiny.pm
+++ b/lib/Term/ReadLine/Tiny.pm
@@ -654,7 +654,7 @@ sub gethistory
 {
 	my $self = shift;
 	my @result = @{$self->{history}};
-	if (grep(":utf8", PerlIO::get_layers($self->{IN})) and $self->{features}->{utf8})
+	if ($self->{features}->{utf8})
 	{
 		for (my $i = 0; $i < @result; $i++)
 		{
@@ -778,7 +778,7 @@ sub readkey
 
 =head2 utf8([$enable])
 
-If C<$enable> is C<TRUE>, all read methods return that binary encoded UTF-8 string.
+If C<$enable> is C<TRUE>, all read methods return that binary encoded UTF-8 string as possible.
 
 Returns the old value.
 
@@ -832,7 +832,7 @@ layer explicitly, if input/output file handles specified with C<new()> or C<newT
 	$term = Term::ReadLine::Tiny->new("", $in, $out);
 	binmode($term->IN, ":utf8");
 	binmode($term->OUT, ":utf8");
-	$term->utf8(0); # to get UTF-8 marked string
+	$term->utf8(0); # to get UTF-8 marked string as possible
 	while ( defined($_ = $term->readline("Prompt: ")) )
 	{
 		print "$_\n";

--- a/lib/Term/ReadLine/Tiny/readline.pm
+++ b/lib/Term/ReadLine/Tiny/readline.pm
@@ -5,7 +5,7 @@ Term::ReadLine::Tiny::readline - A non-OO package of Term::ReadLine::Tiny
 
 =head1 VERSION
 
-version 1.07
+version 1.08
 
 =head1 SYNOPSIS
 
@@ -34,7 +34,7 @@ use Term::ReadLine::Tiny;
 BEGIN
 {
 	require Exporter;
-	our $VERSION     = '1.07';
+	our $VERSION     = '1.08';
 	our @ISA         = qw(Exporter);
 	our @EXPORT      = qw(readline readkey);
 	our @EXPORT_OK   = qw();


### PR DESCRIPTION
- Added keys that starting with ^[O
- Returns binary encoded UTF-8 string when input handle has :utf8 layer and utf8 feature is true